### PR TITLE
Fix handling worktree paths with spaces

### DIFF
--- a/GitWorkTree/Helpers/GitHelper.cs
+++ b/GitWorkTree/Helpers/GitHelper.cs
@@ -21,10 +21,6 @@ namespace GitWorkTree.Helpers
     {
         private static string GitPath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,
             @"CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd\git.exe");
-        private static string QuotePath(string path) =>
-            string.IsNullOrWhiteSpace(path) ? "\"\"" :
-                    ((path = path.Trim().Trim('"')).Any(char.IsWhiteSpace) ? //Does the cleaned string contain spaces? 
-                    $"\"{path}\"" : path);                                   //→ add quotes.
         public static string ToFolderFormat(this string branchName) => Regex.Match(branchName, @"(?:.*\/)?(?:head -> |origin\/|remote\/)?\+?\s*([^'/]+)").Groups[1].Value ?? branchName;
         public static string ToGitCommandExecutableFormat(this string branchName) => Regex.Match(branchName,
                 @"(?:\+?\s?(?:remotes?\/(?:origin|main|upstream)\/(?:HEAD -> (?:origin|main|upstream)\/)?|remotes?\/(?:origin|main|upstream)\/)?|[^\/]+\/)?([^\/]+(?:\/[^\/]+)*)$")
@@ -159,7 +155,7 @@ namespace GitWorkTree.Helpers
             string force = shouldForceCreate ? "-f " : "";
             return await ExecuteAsync(new GitCommandArgs()
             {
-                Argument = $"worktree add {force}{QuotePath(workTreePath)} {branchName.ToGitCommandExecutableFormat()}",
+                Argument = $"worktree add {force}{SolutionHelper.NormalizePath(workTreePath)} {branchName.ToGitCommandExecutableFormat()}",
                 WorkingDirectory = repositoryPath
             }, (line) =>
             {
@@ -172,7 +168,7 @@ namespace GitWorkTree.Helpers
             string force = shouldForceCreate ? "-f " : "";
             return await ExecuteAsync(new GitCommandArgs()
             {
-                Argument = $"worktree remove {force}{QuotePath(workTreePath)}",
+                Argument = $"worktree remove {force}{SolutionHelper.NormalizePath(workTreePath)}",
                 WorkingDirectory = repositoryPath
             }, (line) =>
             {

--- a/GitWorkTree/Helpers/SolutionHelper.cs
+++ b/GitWorkTree/Helpers/SolutionHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace GitWorkTree.Helpers
@@ -8,6 +9,10 @@ namespace GitWorkTree.Helpers
     public static class SolutionHelper
     {
         static LoggingHelper outputWindow = LoggingHelper.Instance;
+        public static string NormalizePath(string path) =>
+             string.IsNullOrWhiteSpace(path) ? "\"\"" :
+                 ((path = path.Trim().Trim('"').TrimEnd('\r', '\n'))
+                  .Any(char.IsWhiteSpace) ? $"\"{path}\"" : path);
         public static string GetRepositoryPath(string solutionPath)
         {
             try
@@ -76,7 +81,7 @@ namespace GitWorkTree.Helpers
         private static bool OpenSolutionInNewInstance(string newSolutionPath, string[] solutionFiles)
         {
             outputWindow?.WriteToOutputWindowAsync($"Opening {newSolutionPath} in new VS instance", true);
-            System.Diagnostics.Process.Start("devenv.exe", solutionFiles[0]);
+            System.Diagnostics.Process.Start("devenv.exe", NormalizePath(solutionFiles[0]));
             return true;
         }
 


### PR DESCRIPTION
This commit updates CreateWorkTreeAsync and RemoveWorkTreeAsync to
properly quote and normalize worktree paths. This ensures paths with
spaces or stray newline characters are handled correctly both when
executing Git commands and when opening solutions.

Fixes #1 